### PR TITLE
Fixed comparison of string length by using the 'str_len' variable ins…

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -68,51 +68,34 @@ gboolean is_hyperlink(gchar *text)
 /* Ellipsize a string according to the settings */
 GString *ellipsize_string(GString *string)
 {
-    gboolean is_utf8 = g_utf8_validate(string->str, -1, NULL);
-    gint str_len = is_utf8 ? g_utf8_strlen(string->str, -1) : string->len;
-    if (string->len > prefs.item_length)
+    gchar *start = NULL,
+          *end   = NULL;
+
+    gint str_len = g_utf8_strlen(string->str, -1);
+    if (str_len > prefs.item_length)
     {
         switch (prefs.ellipsize)
         {
             case PANGO_ELLIPSIZE_START:
-                if (is_utf8)
-                {
-                    gchar *end = g_utf8_substring(string->str, str_len - prefs.item_length, str_len);
-                    g_string_printf(string, "...%s", end);
-                }
-                else
-                {
-                    string = g_string_erase(string, 0, str_len - (prefs.item_length));
-                    string = g_string_prepend(string, "...");
-                }
-                break;
+                end = g_utf8_substring(string->str, str_len - prefs.item_length, str_len);
+                g_string_printf(string, "...%s", end);
+            break;
             case PANGO_ELLIPSIZE_MIDDLE:
-                if (is_utf8)
-                {
-                    gchar *start = g_utf8_substring(string->str, 0, prefs.item_length/2);
-                    gchar *end = g_utf8_substring(string->str, str_len - prefs.item_length/2, str_len);
-                    g_string_printf(string, "%s...%s", start, end);
-                }
-                else
-                {
-                    string = g_string_erase(string, (prefs.item_length/2), str_len - (prefs.item_length));
-                    string = g_string_insert(string, (string->len/2), "...");
-                }
-                break;
+                start = g_utf8_substring(string->str, 0, prefs.item_length/2);
+                end = g_utf8_substring(string->str, str_len - prefs.item_length/2, str_len);
+                g_string_printf(string, "%s...%s", start, end);
+            break;
             case PANGO_ELLIPSIZE_END:
-                if (is_utf8)
-                {
-                    gchar *buff = g_utf8_substring(string->str, 0, prefs.item_length);
-                    g_string_assign(string, buff);
-                }
-                else
-                {
-                    string = g_string_truncate(string, prefs.item_length);
-                }
+                start = g_utf8_substring(string->str, 0, prefs.item_length);
+                g_string_assign(string, start);
                 string = g_string_append(string, "...");
-                break;
+            break;
         }
     }
+
+    g_free(start);
+    g_free(end);
+
     return string;
 }
 


### PR DESCRIPTION
* Fixed comparison of string length by using the 'str_len' variable instead of 'string->len'
* Refactored the code from merge #30. Now by default working with string in utf8 mode.